### PR TITLE
Fixes for PKGBUILD.libxpid

### DIFF
--- a/aur/PKGBUILD.libxpid
+++ b/aur/PKGBUILD.libxpid
@@ -27,5 +27,5 @@ build() {
 package() {
 	cd xpid
 	cd libxpid/build
-	sudo make install
+	make DESTDIR="$pkgdir" install
 }

--- a/aur/PKGBUILD.libxpid
+++ b/aur/PKGBUILD.libxpid
@@ -13,12 +13,11 @@ checkdepends=()
 optdepends=()
 backup=()
 options=()
-source=("git+https://github.com/kris-nova/xpid.git")
+source=("git+https://github.com/kris-nova/xpid.git#tag=$pkgver")
 sha256sums=('SKIP')
 
 build() {
 	cd xpid
-	git checkout tags/$pkgver -b $pkgver
 	cd libxpid
 	./configure
 	cd build


### PR DESCRIPTION
This PR contains two fixes.

First removes the manual checkout. I am a bit uncertain about this one. Please, keep an eye on the result so that it's matching.

The second sets `DESTDIR` to `pkgdir` for `make install` which should help with the permission problem. `pkgdir` is used for bundling installed files and will become the root directory of the package, if I understood the documentation correct.
https://man.archlinux.org/man/PKGBUILD.5

Thanks for a wonderful stream! <3
